### PR TITLE
Add check audience option.

### DIFF
--- a/lib/passport-oauth2-jwt-bearer/strategy.js
+++ b/lib/passport-oauth2-jwt-bearer/strategy.js
@@ -21,7 +21,10 @@ function Strategy(options, keying, verify) {
   
   var audience = options.audience;
   
-  if (!audience) throw new TypeError('OAuth 2.0 JWT bearer strategy requires an audience option');
+  if (!options.skipAudienceCheck) {
+    if (!audience) throw new TypeError('OAuth 2.0 JWT bearer strategy requires an audience option');
+  }
+
   if (!keying) throw new TypeError('OAuth 2.0 JWT bearer strategy requires a keying callback');
   if (!verify) throw new TypeError('OAuth 2.0 JWT bearer strategy requires a verify callback');
 
@@ -35,6 +38,7 @@ function Strategy(options, keying, verify) {
   this._keying = keying;
   this._verify = verify;
   this._passReqToCallback = options.passReqToCallback;
+  this._skipAudienceCheck = options.skipAudienceCheck || false;
 }
 
 /**
@@ -81,7 +85,7 @@ Strategy.prototype.authenticate = function(req) {
   if (!payload.aud) { return this.fail(400); }
   if (!payload.exp) { return this.fail(400); }
   
-  if (this._audience.indexOf(payload.aud) == -1) {
+  if (!this._skipAudienceCheck && this._audience.indexOf(payload.aud) == -1) {
     return this.fail();
   }
   

--- a/test/strategy.jws.test.js
+++ b/test/strategy.jws.test.js
@@ -217,7 +217,40 @@ describe('Strategy', function() {
       expect(status).to.equal(400);
     });
   });
-  
+
+  describe('handling a request with an aud claim that is not that passed in configuration', function() {
+    var challenge, status;
+
+    before(function(done) {
+      chai.passport.use(strategy)
+        .fail(function(c, s) {
+          if (typeof c == 'number') {
+            s = c;
+            c = undefined;
+          }
+
+          challenge = c;
+          status = s;
+          done();
+        })
+        .req(function(req) {
+          req.body = {
+            'client_assertion_type': 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+            'client_assertion': 'eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL2p3dC1pZHAuZXhhbXBsZS5jb20iLCJzdWIiOiJtYWlsdG86bWlrZUBleGFtcGxlLmNvbSIsImF1ZCI6ImRpZmZlcmVudGF1ZGllbmNlIiwiZXhwIjo3NzAyNTg4ODAwfQ.EzpsldV9Z_VWxlpX3GLgtFIALgoCI8HZ8iB2-4tU-7YQCP02mKnWdqz7bT4Gcafnlq1tzeYahvPbR6lX0DgtjVkQ29PYwegwA2DqmLsB3Ih44Bzu7m7zTgFR1UmoHDKk-CHWuFeVPqx2oWFVC_RGkAzzfkI1jfnwStNd20ydhD0'
+          };
+        })
+        .authenticate();
+    });
+
+    it('should fail without challenge', function() {
+      expect(challenge).to.be.undefined;
+    });
+
+    it('should fail without status', function() {
+      expect(status).to.be.undefined;
+    });
+  });
+
   describe('handling a request with an invalid JWS due to missing exp claim', function() {
     var challenge, status;
     

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -9,10 +9,16 @@ describe('Strategy', function() {
     expect(strategy.name).to.equal('oauth2-jwt-bearer');
   });
   
-  it('should throw if constructed without an audience option', function() {
+  it('should throw if constructed without an audience option and without skipAudienceCheck', function() {
     expect(function() {
-      new Strategy();
+      new Strategy(function(){}, function(){});
     }).to.throw(TypeError, 'OAuth 2.0 JWT bearer strategy requires an audience option');
+  });
+
+  it('should not throw if constructed without an audience option but with skipAudienceCheck', function() {
+    expect(function() {
+      new Strategy({ skipAudienceCheck: true }, function(){}, function(){});
+    }).to.not.throw(TypeError, 'OAuth 2.0 JWT bearer strategy requires an audience option');
   });
   
   it('should throw if constructed without a keying callback', function() {


### PR DESCRIPTION
This allows a `skipAudienceCheck` option to be set to a truthy value, which allows the audience to be checked in the verify callback so that it may be done manually. 