### PR TITLE
Added try/catch to handle jwt.verify exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: "node_js"
 node_js:
-  - "0.10"
-  - "0.8"
-#  - "0.6"
-  - "0.4"
+  - "6"
+  - "4"
 
 before_install:
  - "npm install istanbul -g"

--- a/lib/passport-oauth2-jwt-bearer/strategy.js
+++ b/lib/passport-oauth2-jwt-bearer/strategy.js
@@ -109,7 +109,12 @@ Strategy.prototype.authenticate = function(req) {
       // The key has been retrieved, verify the assertion.  `key` is a PEM
       // encoded RSA public key, DSA public key, or X.509 certificate, as
       // supported by Node's `crypto` module.
-      var ok = jwt.verify(assertion, key);
+      try{
+        var ok = jwt.verify(assertion, key);
+      } catch(e){
+        return self.error(e);
+      }
+
       if (!ok) { return self.fail(); }
       doVerifyStep();
     }


### PR DESCRIPTION
Changed node versions in travis as version 0.x versions are not longer maintained (based on https://github.com/nodejs/LTS#lts-schedule)

Included node versions 4 and 6 as they are currently active.

The try catch in the `jwt.verify` is to handle an exception thrown by crypto library when the certificate is not valid (e.g. malformed)