### PR TITLE
Fix forgeable Public/Private Tokens High severity - jws

### DIFF
--- a/lib/passport-oauth2-jwt-bearer/strategy.js
+++ b/lib/passport-oauth2-jwt-bearer/strategy.js
@@ -18,9 +18,9 @@ function Strategy(options, keying, verify) {
     options = undefined;
   }
   options = options || {};
-  
+
   var audience = options.audience;
-  
+
   if (!options.skipAudienceCheck) {
     if (!audience) throw new TypeError('OAuth 2.0 JWT bearer strategy requires an audience option');
   }
@@ -71,20 +71,23 @@ Strategy.prototype.authenticate = function(req) {
   // the keying material has been retrieved.
   var token = jwt.decode(assertion, { json: true });
   if (!token) { return this.fail(400); }
-  
+
   var header = token.header
     , payload = token.payload;
 
   //console.log(token);
   //console.log(payload);
-  
+
   // Validate the assertion.
   // http://tools.ietf.org/html/draft-ietf-oauth-jwt-bearer-07#section-3
   if (!payload.iss) { return this.fail(400); }
   if (!payload.sub) { return this.fail(400); }
   if (!payload.aud) { return this.fail(400); }
   if (!payload.exp) { return this.fail(400); }
-  
+
+  // Validate the header
+  if (!header.alg) { return this.fail(400); }
+
   if (!this._skipAudienceCheck && this._audience.indexOf(payload.aud) == -1) {
     return this.fail();
   }
@@ -105,15 +108,15 @@ Strategy.prototype.authenticate = function(req) {
     function keyed(err, key) {
       if (err) { return self.error(err); }
       if (!key) { return self.fail(); }
-      
+
       // The key has been retrieved, verify the assertion.  `key` is a PEM
       // encoded RSA public key, DSA public key, or X.509 certificate, as
       // supported by Node's `crypto` module.
-      var ok = jwt.verify(assertion, key);
+      var ok = jwt.verify(assertion, header.alg, key);
       if (!ok) { return self.fail(); }
       doVerifyStep();
     }
-    
+
     try {
       if (self._passReqToCallback) {
         var arity = self._keying.length;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./lib/passport-oauth2-jwt-bearer",
   "dependencies": {
     "passport-strategy": "1.x.x",
-    "jws": "0.2.x"
+    "jws": "^3.1.4"
   },
   "devDependencies": {
     "mocha": "1.x.x",


### PR DESCRIPTION
Bump `jws` to latest version to fix vulnerability.
Added algorithm validation (we should not blindly verify the signature, the alg should be whitelisted).